### PR TITLE
Update `vorbis_rs` to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "akasha"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "async-fn-stream",
  "async-trait",
@@ -1573,9 +1573,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vorbis_rs"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8abe117a90371415d7a26f5831b3f7f679fef83f2670a073017951e49f90a5"
+checksum = "b389f6abdad9a8ad80f988cf4d3af68b53514de752faffcb6f259d6a6cf06dfc"
 dependencies = [
  "aotuv_lancer_vorbis_sys",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["recording", "akashic", "audio", "sound", "PIM"]
 cpal = "0.14.2"
 hound = "3.5.0"
 #ogg-opus = "0.1.2"
-vorbis_rs = "0.1.0"
+vorbis_rs = "0.2.0"
 tokio = {version="1.23.0", features=["full"]}
 futures-util = "0.3.25"
 futures-core = "0.3.25"


### PR DESCRIPTION
Hi! :wave: I noticed that this project is using `vorbis_rs` to encode audio, and I wanted to thank you for trying it out! I hope that `vorbis_rs` was useful and easy to use :smile:

I've skimmed through the source and realized that it uses the previous release version of `vorbis_rs`, v0.1.0, but a new `vorbis_rs` version, v0.2.0, was released weeks ago. This version doesn't introduce any new features, but it fixes and improves some minor things you might be interested in, so I'm opening this PR to update it. If you are interested, you can read the full changelog [here](https://github.com/ComunidadAylas/vorbis-rs/blob/master/CHANGELOG.md#020---2023-02-08).

---

By the way, regarding this interesting question you wrote in a code comment:

https://github.com/alxpettit/akasha/blob/858fa37432b35d0f2a5ce0104a113172b98ef62b/src/write_audio.rs#L51-L58

Vorbis does not necessarily flush every block of audio data into the destination stream, and its C API does not provide an obvious way to do this that I can expose in `vorbis_rs`. However, I think it's useful to point out that, after initialization, encoding Ogg Vorbis streams works like this:

- The application hands over a block of samples to Vorbis.
- Vorbis may combine this sample block with previous blocks until it knows which mode to use to encode the audio data. The mode determines the Vorbis audio packet block size. So, roughly speaking, if your application generates blocks of 256 samples per channel, and Vorbis decides to use a packet block size of 1024 samples, four application sample blocks will be combined into a 1024 sample block. The Vorbis encoder implemented by `vorbis_rs` uses block sizes of either 512 or 2048 samples for stereo, 44.1 kHz signals, so this encoder buffering will introduce a delay of ~0.046 s at most.
- After a Vorbis audio packet is created, it must be encapsulated into an Ogg page. By default, the Ogg layer tries to put about 4 KiB worth of Vorbis packets per page, so this can be a significant source of buffering delay until the data is written to the destination.

You can't make the Vorbis layer output packets earlier (unlike Opus, Vorbis was not really designed with strong real-time use cases in mind), but you can tell the Ogg layer to encapsulate less Vorbis packet data per page, up to the point of having an Ogg page per Vorbis packet. This increases the muxing overhead (delimiting an Ogg page takes a few bytes in the stream), but reduces the buffering latency.

To do so, simply set the `minimum_page_data_size` parameter of [`VorbisEncoder::new`](https://docs.rs/vorbis_rs/latest/vorbis_rs/struct.VorbisEncoder.html#method.new) to the desired number of Vorbis packet data bytes to put per page. A very low value of 0 or 1 should generate one Ogg page per Vorbis packet and keep latency to a minimum.